### PR TITLE
feat: Add Nucleo F103RB support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .pio
+.vscode

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,3 +21,8 @@ board = bluepill_f103c8
 board = maple
 ; add identifying macro for this board
 build_flags = -DSTM32F1
+
+[env:nucleo_f103rb]
+board = nucleo_f103rb
+build_flags = -DNUCLEO_F103RB
+board_build.f_cpu = 8000000L

--- a/src/main.c
+++ b/src/main.c
@@ -7,7 +7,7 @@
 #elif NUCLEO_F103RB
 	#include <stm32f10x_gpio.h>
 	#include <stm32f10x_rcc.h>
-    #define SystemCoreClock 8000000
+	#define SystemCoreClock 8000000
 	#define LEDPORT (GPIOB)
 	#define LEDPIN (GPIO_Pin_5)
 	#define ENABLE_GPIO_CLOCK (RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOB, ENABLE))
@@ -66,7 +66,7 @@ int main(void)
 	ENABLE_GPIO_CLOCK;
 	/* use LED pin */
 	gpio.GPIO_Pin = LEDPIN;
-    gpio.GPIO_Speed = GPIO_Speed_2MHz;
+	gpio.GPIO_Speed = GPIO_Speed_2MHz;
 	/* set pin to push-pull output depending on the SPL variant */
 #if STM32F1 || NUCLEO_F103RB
 	gpio.GPIO_Mode = GPIO_Mode_Out_PP;

--- a/src/main.c
+++ b/src/main.c
@@ -4,6 +4,13 @@
 	#define LEDPORT (GPIOC)
 	#define LEDPIN (GPIO_Pin_13)
 	#define ENABLE_GPIO_CLOCK (RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOC, ENABLE))
+#elif NUCLEO_F103RB
+	#include <stm32f10x_gpio.h>
+	#include <stm32f10x_rcc.h>
+    #define SystemCoreClock 8000000
+	#define LEDPORT (GPIOB)
+	#define LEDPIN (GPIO_Pin_5)
+	#define ENABLE_GPIO_CLOCK (RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOB, ENABLE))
 #elif STM32L1
 	#include <stm32l1xx_gpio.h>
 	#include <stm32l1xx_rcc.h>
@@ -59,8 +66,9 @@ int main(void)
 	ENABLE_GPIO_CLOCK;
 	/* use LED pin */
 	gpio.GPIO_Pin = LEDPIN;
+    gpio.GPIO_Speed = GPIO_Speed_2MHz;
 	/* set pin to push-pull output depending on the SPL variant */
-#if STM32F1
+#if STM32F1 || NUCLEO_F103RB
 	gpio.GPIO_Mode = GPIO_Mode_Out_PP;
 #else
 	/* mode: output */


### PR DESCRIPTION
Hey,
so I ran your project on my Nucleo F103RB dev board. I had to make the following changes / fixes:

- Added a "nucleo_f103rb" target. 
- Fixed an issue regarding the clock frequency. My dev board had a `SystemCoreClock` of 8 MHz instead of 74 MHz. Consult [chapter 6.7.1 of the board's user manual](https://www.st.com/resource/en/user_manual/dm00105823-stm32-nucleo-64-boards-mb1136-stmicroelectronics.pdf) for further information.
- Fixed an issue regarding GPIO setup. Additionally, to get your project running, I needed to specify `GPIO_InitTypeDef.GPIO_Speed`.

Other than the aforementioned issues, the new and updated SPL framework ran without any issues.